### PR TITLE
Exclude pip for WSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "postinstall": "python3 -m venv mjpg-env --system-site-packages && . mjpg-env/bin/activate && pip3 install -r tm-mjpg-server/requirements.txt"
+        "postinstall": "python3 -m venv mjpg-env --system-site-packages --without-pip && . mjpg-env/bin/activate && pip3 install -r tm-mjpg-server/requirements.txt"
     },
     "author": "T-Mobile",
     "license": "Apache-2.0",


### PR DESCRIPTION
This is the only way I could get the package to work on Windows with WSL2. I *have not* tested this on the Pi yet - need to test before merging.

Also, I don't know Python very well, so experts please chime in :)